### PR TITLE
Upgrade the NuGet version to 28.1.33 in all .NET Framework projects - Convert Word to Image

### DIFF
--- a/Convert-Word-to-image/.NET-Framework/Convert-Word-to-image/Convert-Word-to-image.csproj
+++ b/Convert-Word-to-image/.NET-Framework/Convert-Word-to-image/Convert-Word-to-image.csproj
@@ -34,23 +34,23 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Syncfusion.Compression.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Compression.Base.27.1.53\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Compression.Base.28.1.33\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.WinForms.27.1.53\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.WinForms.28.1.33\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Licensing.27.1.53\lib\net462\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Licensing.28.1.33\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.OfficeChart.Base.27.1.53\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.OfficeChart.Base.28.1.33\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChartToImageConverter.Wpf, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.OfficeChartToImageConverter.WinForms.27.1.53\lib\net462\Syncfusion.OfficeChartToImageConverter.Wpf.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChartToImageConverter.Wpf, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.OfficeChartToImageConverter.WinForms.28.1.33\lib\net462\Syncfusion.OfficeChartToImageConverter.Wpf.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.SfChart.WPF, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.SfChart.WPF.27.1.53\lib\net462\Syncfusion.SfChart.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.SfChart.WPF, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.SfChart.WPF.28.1.33\lib\net462\Syncfusion.SfChart.WPF.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Convert-Word-to-image/.NET-Framework/Convert-Word-to-image/packages.config
+++ b/Convert-Word-to-image/.NET-Framework/Convert-Word-to-image/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Syncfusion.Compression.Base" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.WinForms" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.Licensing" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChart.Base" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChartToImageConverter.WinForms" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.SfChart.WPF" version="27.1.53" targetFramework="net462" />
+  <package id="Syncfusion.Compression.Base" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.WinForms" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.Licensing" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChart.Base" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChartToImageConverter.WinForms" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.SfChart.WPF" version="28.1.33" targetFramework="net462" />
 </packages>

--- a/First-page-of-Word-to-image/.NET-Framework/First-page-of-Word-to-image/First-page-of-Word-to-image.csproj
+++ b/First-page-of-Word-to-image/.NET-Framework/First-page-of-Word-to-image/First-page-of-Word-to-image.csproj
@@ -34,23 +34,23 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Syncfusion.Compression.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Compression.Base.27.1.53\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Compression.Base.28.1.33\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.WinForms.27.1.53\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.WinForms.28.1.33\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Licensing.27.1.53\lib\net462\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Licensing.28.1.33\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.OfficeChart.Base.27.1.53\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.OfficeChart.Base.28.1.33\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChartToImageConverter.Wpf, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.OfficeChartToImageConverter.WinForms.27.1.53\lib\net462\Syncfusion.OfficeChartToImageConverter.Wpf.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChartToImageConverter.Wpf, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.OfficeChartToImageConverter.WinForms.28.1.33\lib\net462\Syncfusion.OfficeChartToImageConverter.Wpf.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.SfChart.WPF, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.SfChart.WPF.27.1.53\lib\net462\Syncfusion.SfChart.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.SfChart.WPF, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.SfChart.WPF.28.1.33\lib\net462\Syncfusion.SfChart.WPF.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/First-page-of-Word-to-image/.NET-Framework/First-page-of-Word-to-image/packages.config
+++ b/First-page-of-Word-to-image/.NET-Framework/First-page-of-Word-to-image/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Syncfusion.Compression.Base" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.WinForms" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.Licensing" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChart.Base" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChartToImageConverter.WinForms" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.SfChart.WPF" version="27.1.53" targetFramework="net462" />
+  <package id="Syncfusion.Compression.Base" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.WinForms" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.Licensing" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChart.Base" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChartToImageConverter.WinForms" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.SfChart.WPF" version="28.1.33" targetFramework="net462" />
 </packages>

--- a/Specific-range-of-pages-to-image/.NET-Framework/Specific-range-of-pages-to-image/Specific-range-of-pages-to-image.csproj
+++ b/Specific-range-of-pages-to-image/.NET-Framework/Specific-range-of-pages-to-image/Specific-range-of-pages-to-image.csproj
@@ -34,23 +34,23 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Syncfusion.Compression.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Compression.Base.27.1.53\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Compression.Base.28.1.33\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.WinForms.27.1.53\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.WinForms.28.1.33\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Licensing.27.1.53\lib\net462\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Licensing.28.1.33\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.OfficeChart.Base.27.1.53\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.OfficeChart.Base.28.1.33\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChartToImageConverter.Wpf, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.OfficeChartToImageConverter.WinForms.27.1.53\lib\net462\Syncfusion.OfficeChartToImageConverter.Wpf.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChartToImageConverter.Wpf, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.OfficeChartToImageConverter.WinForms.28.1.33\lib\net462\Syncfusion.OfficeChartToImageConverter.Wpf.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.SfChart.WPF, Version=27.1462.53.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.SfChart.WPF.27.1.53\lib\net462\Syncfusion.SfChart.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.SfChart.WPF, Version=28.1462.33.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.SfChart.WPF.28.1.33\lib\net462\Syncfusion.SfChart.WPF.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Specific-range-of-pages-to-image/.NET-Framework/Specific-range-of-pages-to-image/packages.config
+++ b/Specific-range-of-pages-to-image/.NET-Framework/Specific-range-of-pages-to-image/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Syncfusion.Compression.Base" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.WinForms" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.Licensing" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChart.Base" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChartToImageConverter.WinForms" version="27.1.53" targetFramework="net462" />
-  <package id="Syncfusion.SfChart.WPF" version="27.1.53" targetFramework="net462" />
+  <package id="Syncfusion.Compression.Base" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.WinForms" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.Licensing" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChart.Base" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChartToImageConverter.WinForms" version="28.1.33" targetFramework="net462" />
+  <package id="Syncfusion.SfChart.WPF" version="28.1.33" targetFramework="net462" />
 </packages>


### PR DESCRIPTION
Description:
Upgraded the NuGet version to 28.1.33 in all .NET Framework projects for Convert Word to Image repository.