### PR TITLE
Upgrade the NuGet version to 31.1.17 in all .NET Framework projects - Convert Word to Image

### DIFF
--- a/Convert-Word-to-image/.NET-Framework/Convert-Word-to-image/Convert-Word-to-image.csproj
+++ b/Convert-Word-to-image/.NET-Framework/Convert-Word-to-image/Convert-Word-to-image.csproj
@@ -43,6 +43,9 @@
     <Reference Include="Syncfusion.Licensing, Version=31.1462.17.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
       <HintPath>..\packages\Syncfusion.Licensing.31.1.17\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
+	<Reference Include="Syncfusion.Markdown, Version=31.1462.17.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Markdown.31.1.17\lib\net462\Syncfusion.Markdown.dll</HintPath>
+    </Reference>
     <Reference Include="Syncfusion.OfficeChart.Base, Version=31.1462.17.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
       <HintPath>..\packages\Syncfusion.OfficeChart.Base.31.1.17\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>

--- a/Convert-Word-to-image/.NET-Framework/Convert-Word-to-image/Convert-Word-to-image.csproj
+++ b/Convert-Word-to-image/.NET-Framework/Convert-Word-to-image/Convert-Word-to-image.csproj
@@ -34,23 +34,23 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Syncfusion.Compression.Base, Version=30.1462.37.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Compression.Base.30.1.37\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=31.1462.17.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Compression.Base.31.1.17\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=30.1462.37.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.WinForms.30.1.37\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=31.1462.17.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.WinForms.31.1.17\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=30.1462.37.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Licensing.30.1.37\lib\net462\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=31.1462.17.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Licensing.31.1.17\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=30.1462.37.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.OfficeChart.Base.30.1.37\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=31.1462.17.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.OfficeChart.Base.31.1.17\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChartToImageConverter.Wpf, Version=30.1462.37.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.OfficeChartToImageConverter.WinForms.30.1.37\lib\net462\Syncfusion.OfficeChartToImageConverter.Wpf.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChartToImageConverter.Wpf, Version=31.1462.17.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.OfficeChartToImageConverter.WinForms.31.1.17\lib\net462\Syncfusion.OfficeChartToImageConverter.Wpf.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.SfChart.WPF, Version=30.1462.37.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.SfChart.WPF.30.1.37\lib\net462\Syncfusion.SfChart.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.SfChart.WPF, Version=31.1462.17.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.SfChart.WPF.31.1.17\lib\net462\Syncfusion.SfChart.WPF.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Convert-Word-to-image/.NET-Framework/Convert-Word-to-image/packages.config
+++ b/Convert-Word-to-image/.NET-Framework/Convert-Word-to-image/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Syncfusion.Compression.Base" version="30.1.37" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.WinForms" version="30.1.37" targetFramework="net462" />
-  <package id="Syncfusion.Licensing" version="30.1.37" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChart.Base" version="30.1.37" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChartToImageConverter.WinForms" version="30.1.37" targetFramework="net462" />
-  <package id="Syncfusion.SfChart.WPF" version="30.1.37" targetFramework="net462" />
+  <package id="Syncfusion.Compression.Base" version="31.1.17" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.WinForms" version="31.1.17" targetFramework="net462" />
+  <package id="Syncfusion.Licensing" version="31.1.17" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChart.Base" version="31.1.17" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChartToImageConverter.WinForms" version="31.1.17" targetFramework="net462" />
+  <package id="Syncfusion.SfChart.WPF" version="31.1.17" targetFramework="net462" />
 </packages>

--- a/Convert-Word-to-image/.NET-Framework/Convert-Word-to-image/packages.config
+++ b/Convert-Word-to-image/.NET-Framework/Convert-Word-to-image/packages.config
@@ -3,6 +3,7 @@
   <package id="Syncfusion.Compression.Base" version="31.1.17" targetFramework="net462" />
   <package id="Syncfusion.DocIO.WinForms" version="31.1.17" targetFramework="net462" />
   <package id="Syncfusion.Licensing" version="31.1.17" targetFramework="net462" />
+  <package id="Syncfusion.Markdown" version="31.1.17" targetFramework="net462" />
   <package id="Syncfusion.OfficeChart.Base" version="31.1.17" targetFramework="net462" />
   <package id="Syncfusion.OfficeChartToImageConverter.WinForms" version="31.1.17" targetFramework="net462" />
   <package id="Syncfusion.SfChart.WPF" version="31.1.17" targetFramework="net462" />

--- a/First-page-of-Word-to-image/.NET-Framework/First-page-of-Word-to-image/First-page-of-Word-to-image.csproj
+++ b/First-page-of-Word-to-image/.NET-Framework/First-page-of-Word-to-image/First-page-of-Word-to-image.csproj
@@ -43,6 +43,9 @@
     <Reference Include="Syncfusion.Licensing, Version=31.1462.17.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
       <HintPath>..\packages\Syncfusion.Licensing.31.1.17\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
+	<Reference Include="Syncfusion.Markdown, Version=31.1462.17.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Markdown.31.1.17\lib\net462\Syncfusion.Markdown.dll</HintPath>
+    </Reference>
     <Reference Include="Syncfusion.OfficeChart.Base, Version=31.1462.17.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
       <HintPath>..\packages\Syncfusion.OfficeChart.Base.31.1.17\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>

--- a/First-page-of-Word-to-image/.NET-Framework/First-page-of-Word-to-image/First-page-of-Word-to-image.csproj
+++ b/First-page-of-Word-to-image/.NET-Framework/First-page-of-Word-to-image/First-page-of-Word-to-image.csproj
@@ -34,23 +34,23 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Syncfusion.Compression.Base, Version=30.1462.37.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Compression.Base.30.1.37\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=31.1462.17.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Compression.Base.31.1.17\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=30.1462.37.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.WinForms.30.1.37\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=31.1462.17.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.WinForms.31.1.17\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=30.1462.37.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Licensing.30.1.37\lib\net462\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=31.1462.17.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Licensing.31.1.17\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=30.1462.37.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.OfficeChart.Base.30.1.37\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=31.1462.17.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.OfficeChart.Base.31.1.17\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChartToImageConverter.Wpf, Version=30.1462.37.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.OfficeChartToImageConverter.WinForms.30.1.37\lib\net462\Syncfusion.OfficeChartToImageConverter.Wpf.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChartToImageConverter.Wpf, Version=31.1462.17.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.OfficeChartToImageConverter.WinForms.31.1.17\lib\net462\Syncfusion.OfficeChartToImageConverter.Wpf.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.SfChart.WPF, Version=30.1462.37.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.SfChart.WPF.30.1.37\lib\net462\Syncfusion.SfChart.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.SfChart.WPF, Version=31.1462.17.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.SfChart.WPF.31.1.17\lib\net462\Syncfusion.SfChart.WPF.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/First-page-of-Word-to-image/.NET-Framework/First-page-of-Word-to-image/packages.config
+++ b/First-page-of-Word-to-image/.NET-Framework/First-page-of-Word-to-image/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Syncfusion.Compression.Base" version="30.1.37" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.WinForms" version="30.1.37" targetFramework="net462" />
-  <package id="Syncfusion.Licensing" version="30.1.37" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChart.Base" version="30.1.37" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChartToImageConverter.WinForms" version="30.1.37" targetFramework="net462" />
-  <package id="Syncfusion.SfChart.WPF" version="30.1.37" targetFramework="net462" />
+  <package id="Syncfusion.Compression.Base" version="31.1.17" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.WinForms" version="31.1.17" targetFramework="net462" />
+  <package id="Syncfusion.Licensing" version="31.1.17" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChart.Base" version="31.1.17" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChartToImageConverter.WinForms" version="31.1.17" targetFramework="net462" />
+  <package id="Syncfusion.SfChart.WPF" version="31.1.17" targetFramework="net462" />
 </packages>

--- a/First-page-of-Word-to-image/.NET-Framework/First-page-of-Word-to-image/packages.config
+++ b/First-page-of-Word-to-image/.NET-Framework/First-page-of-Word-to-image/packages.config
@@ -3,6 +3,7 @@
   <package id="Syncfusion.Compression.Base" version="31.1.17" targetFramework="net462" />
   <package id="Syncfusion.DocIO.WinForms" version="31.1.17" targetFramework="net462" />
   <package id="Syncfusion.Licensing" version="31.1.17" targetFramework="net462" />
+  <package id="Syncfusion.Markdown" version="31.1.17" targetFramework="net462" />
   <package id="Syncfusion.OfficeChart.Base" version="31.1.17" targetFramework="net462" />
   <package id="Syncfusion.OfficeChartToImageConverter.WinForms" version="31.1.17" targetFramework="net462" />
   <package id="Syncfusion.SfChart.WPF" version="31.1.17" targetFramework="net462" />

--- a/Specific-range-of-pages-to-image/.NET-Framework/Specific-range-of-pages-to-image/Specific-range-of-pages-to-image.csproj
+++ b/Specific-range-of-pages-to-image/.NET-Framework/Specific-range-of-pages-to-image/Specific-range-of-pages-to-image.csproj
@@ -43,6 +43,9 @@
     <Reference Include="Syncfusion.Licensing, Version=31.1462.17.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
       <HintPath>..\packages\Syncfusion.Licensing.31.1.17\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
+	<Reference Include="Syncfusion.Markdown, Version=31.1462.17.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Markdown.31.1.17\lib\net462\Syncfusion.Markdown.dll</HintPath>
+    </Reference>
     <Reference Include="Syncfusion.OfficeChart.Base, Version=31.1462.17.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
       <HintPath>..\packages\Syncfusion.OfficeChart.Base.31.1.17\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>

--- a/Specific-range-of-pages-to-image/.NET-Framework/Specific-range-of-pages-to-image/Specific-range-of-pages-to-image.csproj
+++ b/Specific-range-of-pages-to-image/.NET-Framework/Specific-range-of-pages-to-image/Specific-range-of-pages-to-image.csproj
@@ -34,23 +34,23 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Syncfusion.Compression.Base, Version=30.1462.37.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Compression.Base.30.1.37\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
+    <Reference Include="Syncfusion.Compression.Base, Version=31.1462.17.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Compression.Base.31.1.17\lib\net462\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.DocIO.Base, Version=30.1462.37.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.DocIO.WinForms.30.1.37\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
+    <Reference Include="Syncfusion.DocIO.Base, Version=31.1462.17.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.DocIO.WinForms.31.1.17\lib\net462\Syncfusion.DocIO.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.Licensing, Version=30.1462.37.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.Licensing.30.1.37\lib\net462\Syncfusion.Licensing.dll</HintPath>
+    <Reference Include="Syncfusion.Licensing, Version=31.1462.17.0, Culture=neutral, PublicKeyToken=632609b4d040f6b4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.Licensing.31.1.17\lib\net462\Syncfusion.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChart.Base, Version=30.1462.37.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.OfficeChart.Base.30.1.37\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChart.Base, Version=31.1462.17.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.OfficeChart.Base.31.1.17\lib\net462\Syncfusion.OfficeChart.Base.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.OfficeChartToImageConverter.Wpf, Version=30.1462.37.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.OfficeChartToImageConverter.WinForms.30.1.37\lib\net462\Syncfusion.OfficeChartToImageConverter.Wpf.dll</HintPath>
+    <Reference Include="Syncfusion.OfficeChartToImageConverter.Wpf, Version=31.1462.17.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.OfficeChartToImageConverter.WinForms.31.1.17\lib\net462\Syncfusion.OfficeChartToImageConverter.Wpf.dll</HintPath>
     </Reference>
-    <Reference Include="Syncfusion.SfChart.WPF, Version=30.1462.37.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
-      <HintPath>..\packages\Syncfusion.SfChart.WPF.30.1.37\lib\net462\Syncfusion.SfChart.WPF.dll</HintPath>
+    <Reference Include="Syncfusion.SfChart.WPF, Version=31.1462.17.0, Culture=neutral, PublicKeyToken=3d67ed1f87d44c89, processorArchitecture=MSIL">
+      <HintPath>..\packages\Syncfusion.SfChart.WPF.31.1.17\lib\net462\Syncfusion.SfChart.WPF.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Specific-range-of-pages-to-image/.NET-Framework/Specific-range-of-pages-to-image/packages.config
+++ b/Specific-range-of-pages-to-image/.NET-Framework/Specific-range-of-pages-to-image/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Syncfusion.Compression.Base" version="30.1.37" targetFramework="net462" />
-  <package id="Syncfusion.DocIO.WinForms" version="30.1.37" targetFramework="net462" />
-  <package id="Syncfusion.Licensing" version="30.1.37" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChart.Base" version="30.1.37" targetFramework="net462" />
-  <package id="Syncfusion.OfficeChartToImageConverter.WinForms" version="30.1.37" targetFramework="net462" />
-  <package id="Syncfusion.SfChart.WPF" version="30.1.37" targetFramework="net462" />
+  <package id="Syncfusion.Compression.Base" version="31.1.17" targetFramework="net462" />
+  <package id="Syncfusion.DocIO.WinForms" version="31.1.17" targetFramework="net462" />
+  <package id="Syncfusion.Licensing" version="31.1.17" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChart.Base" version="31.1.17" targetFramework="net462" />
+  <package id="Syncfusion.OfficeChartToImageConverter.WinForms" version="31.1.17" targetFramework="net462" />
+  <package id="Syncfusion.SfChart.WPF" version="31.1.17" targetFramework="net462" />
 </packages>

--- a/Specific-range-of-pages-to-image/.NET-Framework/Specific-range-of-pages-to-image/packages.config
+++ b/Specific-range-of-pages-to-image/.NET-Framework/Specific-range-of-pages-to-image/packages.config
@@ -3,6 +3,7 @@
   <package id="Syncfusion.Compression.Base" version="31.1.17" targetFramework="net462" />
   <package id="Syncfusion.DocIO.WinForms" version="31.1.17" targetFramework="net462" />
   <package id="Syncfusion.Licensing" version="31.1.17" targetFramework="net462" />
+  <package id="Syncfusion.Markdown" version="31.1.17" targetFramework="net462" />
   <package id="Syncfusion.OfficeChart.Base" version="31.1.17" targetFramework="net462" />
   <package id="Syncfusion.OfficeChartToImageConverter.WinForms" version="31.1.17" targetFramework="net462" />
   <package id="Syncfusion.SfChart.WPF" version="31.1.17" targetFramework="net462" />


### PR DESCRIPTION
Upgrade the NuGet version to 31.1.17 in all .NET Framework projects - Convert Word to Image